### PR TITLE
Repair remote URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 25.4 (------)
 
-...
+Bug Fixes:
+
+* Repair "View at..." links in tree view context menus.
 
 ## 25.3 (221108)
 

--- a/src/trees/BuildTreeManager.js
+++ b/src/trees/BuildTreeManager.js
@@ -332,17 +332,19 @@ export class BuildTreeManager extends TreeManager {
 
         if (ise.util.libpathIsRemote(item.libpath)) {
             let modpath = item.libpath;
-            let isDir = false;
             let sourceRow = null;
+            let modIsTerm;
             if (item.type === "MODULE") {
-                if (!item.terminal) {
-                    isDir = true;
-                }
+                modIsTerm = item.isTerminal;
             } else {
+                // Any item in the structure tree that is not a module, must be an entity
+                // defined within (and at the top level of) a module.
                 modpath = item.modpath;
                 sourceRow = item.sourceRow;
+                const parentItem = treeNode.tree.model.store.get(item.parent);
+                modIsTerm = parentItem.isTerminal;
             }
-            const url = ise.util.libpath2remoteHostPageUrl(modpath, version, isDir, sourceRow);
+            const url = ise.util.libpath2remoteHostPageUrl(modpath, version, false, sourceRow, modIsTerm);
             const host = modpath.startsWith('gh.') ? 'GitHub' : 'BitBucket';
             cm.addChild(new dojo.MenuSeparator());
             cm.addChild(new dojo.MenuItem({

--- a/src/trees/FsTreeManager.js
+++ b/src/trees/FsTreeManager.js
@@ -234,9 +234,10 @@ export class FsTreeManager extends TreeManager {
         }
 
         if (ise.util.libpathIsRemote(item.libpath)) {
-            let modpath = item.libpath;
-            let isDir = item.type === "DIR";
-            const url = ise.util.libpath2remoteHostPageUrl(modpath, "WIP", isDir, null);
+            const modpath = item.libpath;
+            const isDir = item.type === "DIR";
+            const modIsTerm = (!isDir && item.name !== '__.pfsc');
+            const url = ise.util.libpath2remoteHostPageUrl(modpath, "WIP", isDir, null, modIsTerm);
             const host = modpath.startsWith('gh.') ? 'GitHub' : 'BitBucket';
             cm.addChild(new dojo.MenuSeparator());
             cm.addChild(new dojo.MenuItem({

--- a/src/util.js
+++ b/src/util.js
@@ -235,11 +235,13 @@ util.getRepoPart = moose.getRepoPart;
  *   we make the URL for the given libpath _as a file_.
  * @param sourceRow: when `isDir` is false, you may pass a positive integer
  *   here, naming a row in the source file you want to select.
+ * @param modIsTerm: when `isDir` is false, you may pass a boolean indicating
+ *   whether the module in which this item lives is a terminal module.
  *
  * @return: URL string, or null if the given libpath does not
  *   point to a known remote host.
  */
-util.libpath2remoteHostPageUrl = function(libpath, version, isDir, sourceRow) {
+util.libpath2remoteHostPageUrl = function(libpath, version, isDir, sourceRow, modIsTerm) {
     const lpParts = libpath.split('.');
     const host = lpParts[0];
     if (!['gh', 'bb'].includes(host)) {
@@ -250,17 +252,21 @@ util.libpath2remoteHostPageUrl = function(libpath, version, isDir, sourceRow) {
         gh: 'https://github.com',
         bb: 'https://bitbucket.org',
     }[host]);
-    urlParts.push(lpParts[1]); // user
+    urlParts.push(lpParts[1]); // owner
     urlParts.push(lpParts[2]); // repo
     urlParts.push(host === 'bb' ? 'src' : isDir ? 'tree' : 'blob');
-    urlParts.push(version === "WIP" ? 'master' : version);
+    urlParts.push(version === "WIP" ? 'main' : version);
     urlParts = urlParts.concat(lpParts.slice(3));
     if (!isDir) {
         let suffix = '.pfsc'
         if (sourceRow) {
             suffix += `#${host === 'gh' ? "L" : "lines-"}${sourceRow}`;
         }
-        urlParts[urlParts.length - 1] += suffix;
+        if (modIsTerm) {
+            urlParts[urlParts.length - 1] += suffix;
+        } else {
+            urlParts.push('__' + suffix);
+        }
     } else if (host === 'bb') {
         // BitBucket likes directories to end with a '/'
         urlParts.push('');


### PR DESCRIPTION
Fixes #3 

We repair the "View at..." links in tree view context menus, which were not properly accounting for whether a module was terminal or not.